### PR TITLE
Add compose file for releases diff

### DIFF
--- a/releases-diff/README.md
+++ b/releases-diff/README.md
@@ -1,0 +1,19 @@
+# Docker compose template for several PrestaShop releases diff
+
+In case you want to compare two releases of PrestaShop, you can use this docker-compose template.
+
+## Pre-requesites:
+* Add your PrestaShop release archive in the test folder, with the exact name `release.zip`.
+* Some parameters can be changed in the `docker-compose.yml` file, you can set the PrestaShop version you want to use as reference.
+* To make your blackfire account working with this stack, you MUST declare 4 environment variables, as explained in the official documentation: https://blackfire.io/docs/integrations/docker
+* When you are ready, launch the stack with the following command:
+
+```
+docker-compose up
+```
+
+## Runing containers:
+
+Two websites will be deployed:
+The reference release: http://localhost:8001
+The release to be tested as comparison: http://localhost:8002

--- a/releases-diff/build-add-blackfire/Dockerfile
+++ b/releases-diff/build-add-blackfire/Dockerfile
@@ -1,4 +1,3 @@
-
 ARG psversion
 FROM prestashop/prestashop:$psversion
 

--- a/releases-diff/build-add-blackfire/Dockerfile
+++ b/releases-diff/build-add-blackfire/Dockerfile
@@ -1,0 +1,9 @@
+
+ARG psversion
+FROM prestashop/prestashop:$psversion
+
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
+    && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini

--- a/releases-diff/docker-compose.yml
+++ b/releases-diff/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '2'
+
+services:
+    mysql:
+        image: mysql
+        ports:
+            - "3306"
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: prestashop
+    blackfire:
+      image: blackfire/blackfire
+      environment:
+            BLACKFIRE_SERVER_ID
+            BLACKFIRE_SERVER_TOKEN
+    reference-release:
+        build:
+            context: build-add-blackfire
+            args:
+                psversion: 1.7.2.4
+        environment:
+            DB_SERVER: mysql
+            DB_PASSWD: root
+            DB_NAME: prestashop-reference
+            PS_DOMAIN: localhost:8001
+            PS_INSTALL_AUTO: 1
+            PS_ERASE_DB: 1
+            PS_FOLDER_ADMIN: admin-dev
+            PS_FOLDER_INSTALL: install-dev
+            BLACKFIRE_CLIENT_ID
+            BLACKFIRE_CLIENT_TOKEN
+        depends_on:
+        depends_on:
+            - mysql
+        ports:
+            - "8001:80"
+    test-release:
+      build: test
+      environment:
+          DB_SERVER: mysql
+          DB_PASSWD: root
+          DB_NAME: prestashop-test
+          PS_DOMAIN: localhost:8002
+          PS_INSTALL_AUTO: 1
+          PS_ERASE_DB: 1
+          PS_FOLDER_ADMIN: admin-dev
+          PS_FOLDER_INSTALL: install-dev
+          BLACKFIRE_CLIENT_ID
+          BLACKFIRE_CLIENT_TOKEN
+      depends_on:
+          - mysql
+      ports:
+          - "8002:80"

--- a/releases-diff/docker-compose.yml
+++ b/releases-diff/docker-compose.yml
@@ -36,6 +36,8 @@ services:
             - "8001:80"
     test-release:
       build: test
+      args:
+          psversion: 1.7.2.4
       environment:
           DB_SERVER: mysql
           DB_PASSWD: root

--- a/releases-diff/test/Dockerfile
+++ b/releases-diff/test/Dockerfile
@@ -1,4 +1,5 @@
-FROM prestashop/prestashop:1.7
+ARG psversion
+FROM prestashop/prestashop:$psversion
 
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \

--- a/releases-diff/test/Dockerfile
+++ b/releases-diff/test/Dockerfile
@@ -1,0 +1,17 @@
+FROM prestashop/prestashop:1.7
+
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
+    && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini
+
+RUN rm /var/www/html/* -rf
+
+# Copy files
+ADD release.zip /tmp/prestashop.zip
+RUN rm -rf /tmp/data-ps \
+  && mkdir -p /tmp/data-ps \
+	&& unzip -q /tmp/prestashop.zip -d /tmp/data-ps/ \
+	&& bash /tmp/ps-extractor.sh /tmp/data-ps \
+&& rm /tmp/prestashop.zip


### PR DESCRIPTION
# Docker compose template for several PrestaShop releases diff

In case you want to compare two releases of PrestaShop, you can use this docker-compose template.

## Pre-requesites:
* Add your PrestaShop release archive in the test folder, with the exact name `release.zip`.
* Some parameters can be changed in the `docker-compose.yml` file, you can set the PrestaShop version you want to use as reference.
* To make your blackfire account working with this stack, you MUST declare 4 environment variables, as explained in the official documentation: https://blackfire.io/docs/integrations/docker
* When you are ready, launch the stack with the following command:

```
docker-compose up
```

## Runing containers:

Two websites will be deployed:
The reference release: http://localhost:8001
The release to be tested as comparison: http://localhost:8002
