### PR TITLE
Add docker compose stack example for autoupgrade

### DIFF
--- a/autoupgrade-stack/.env
+++ b/autoupgrade-stack/.env
@@ -1,0 +1,2 @@
+PS_TAG=1.7-7.2
+MYSQL_TAG=5.7

--- a/autoupgrade-stack/.gitignore
+++ b/autoupgrade-stack/.gitignore
@@ -1,0 +1,2 @@
+autoupgrade/
+shopContents/

--- a/autoupgrade-stack/README.md
+++ b/autoupgrade-stack/README.md
@@ -1,0 +1,51 @@
+# Autoupgrade stack
+
+## What does this folder contain?
+
+The `docker-compose.yml` contains a configuration that allows you to run PrestaShop with the upgrade module mounted as a volume.
+
+This stack can be used for development and testing of the module, therefore xDebug will be present.
+
+## How to run this shop
+
+### Pre-requesites
+
+To initialize your environment properly, the upgrade module needs to be present in this directory in the folder `autoupgrade`.
+
+```bash
+git clone https://github.com/PrestaShop/autoupgrade.git
+# or
+ln -s [path/to/your/module]/autoupgrade
+```
+Additional commands may be needed inside the module folder to have it ready to run (i.e Composer).
+
+### Starting-up
+
+When ready, run the following command:
+
+```bash
+docker compose up
+```
+
+A release of PrestaShop will be downloaded and installed on startup. xDebug will be installed between the installation of PrestaShop and Apache startup.
+
+Once ready, your shop can be reached at the address http://localhost:8081 (default conf).
+
+xDebug is configured to display full stack-traces and allow debuggers to listen on port 9007.
+
+## Notes
+
+### Permission on upgrade module
+
+The container may not have write access to the `autoupgrade` directory. This can be reported on the upgrade checklist, where the shop cannot write on the `modules/` folder.
+
+A solution that won't impact the diff of the repository is to change the ownership of this folder and its child elements.
+
+```bash
+chown <your_user>:www-data -R autoupgrade
+```
+
+### Enabling the shopContent volume 
+
+When uncommenting the volume to get the shop files inside the `shopContents/` directory, note you may need to erase this folder before starting over.
+If you keep the folder as-is, you may encounter a message "Shop is already installed" on startup and a non-working shop.

--- a/autoupgrade-stack/README.md
+++ b/autoupgrade-stack/README.md
@@ -33,6 +33,16 @@ Once ready, your shop can be reached at the address http://localhost:8081 (defau
 
 xDebug is configured to display full stack-traces and allow debuggers to listen on port 9007.
 
+## Customization options
+
+Default versions for PrestaShop and Mysql are provided in the `.env` file. To customize these values, additional environment files can be created and provided in the start command.
+
+```bash
+docker compose --env-file .env --env-file .env.override up
+```
+
+
+
 ## Notes
 
 ### Permission on upgrade module

--- a/autoupgrade-stack/build/docker-php-ext-xdebug.ini
+++ b/autoupgrade-stack/build/docker-php-ext-xdebug.ini
@@ -1,0 +1,7 @@
+zend_extension=xdebug.so
+
+xdebug.client_host=172.17.0.1
+xdebug.client_port=9007
+xdebug.mode=debug
+xdebug.start_with_request=yes
+

--- a/autoupgrade-stack/build/init-xdebug.sh
+++ b/autoupgrade-stack/build/init-xdebug.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pecl install -f xdebug
+echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini;
+

--- a/autoupgrade-stack/docker-compose.yml
+++ b/autoupgrade-stack/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+    mysql:
+        image: mysql:${MYSQL_TAG}
+        ports:
+            - "3306"
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: psreference
+    shop:
+        image: prestashop/prestashop:${PS_TAG}
+        volumes:
+            - ./autoupgrade:/var/www/html/modules/autoupgrade
+            # Comment the next two lines if you don't need xDebug
+            - ./build/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+            - ./build/init-xdebug.sh:/tmp/init-scripts/init-xdebug.sh
+            # Uncomment if you need access to the shop files
+            # - ./shopContents:/var/www/html
+        environment:
+            DB_SERVER: mysql
+            DB_PASSWD: root
+            DB_NAME: psreference
+            PS_DOMAIN: localhost:8001
+            PS_INSTALL_AUTO: 1
+            PS_ERASE_DB: 1
+            PS_INSTALL_DB: 1
+            PS_FOLDER_ADMIN: admin-dev
+            PS_FOLDER_INSTALL: install-dev
+            PS_DEV_MODE: 1
+            PS_LANGUAGE: fr
+        depends_on:
+            - mysql
+        ports:
+            - "8001:80"
+            - "9007:9007"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR adds a docker stack to run a dev environment for the autoupgrade module
| Type?             | new feature
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | /
| Sponsor company   | /
| How to test?      | Follow the contents of `autoupgrade-stack/README.md` to have the environment up and running.

:notebook:  At the same time this PR is reviewed, the branch `autoupgrade-test` on the base repository can be dropped.